### PR TITLE
ci: PRでリンクチェックを必須化

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,6 +1,10 @@
 name: Check Links
 
 on:
+  # PRで実行（マージ前チェック）
+  pull_request:
+    branches:
+      - main
   # 毎週月曜 9:00 JST (日曜 24:00 UTC)
   schedule:
     - cron: '0 0 * * 1'
@@ -30,7 +34,12 @@ jobs:
       - name: Run link checker
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: uv run python scripts/check_links.py --create-issue
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            uv run python scripts/check_links.py
+          else
+            uv run python scripts/check_links.py --create-issue
+          fi
 
       - name: Upload results
         if: always()


### PR DESCRIPTION
## 変更内容
- check-links workflow に `pull_request` トリガーを追加
- PR 時は issue 作成をスキップし、定期実行時のみ issue を作成するよう条件分岐を追加

## 補足
マージ後、Settings → Branches でブランチ保護ルールを設定して `check-links` を必須ステータスチェックにする必要があります。