### PR TITLE
fix: oEmbed APIのエンドポイントを publish.x.com に変更

### DIFF
--- a/main.py
+++ b/main.py
@@ -185,7 +185,7 @@ def define_env(env):
             html = cache[tweet_id]["html"]
         else:
             # キャッシュになければ API を叩く
-            api_url = "https://publish.twitter.com/oembed?" + urllib.parse.urlencode(
+            api_url = "https://publish.x.com/oembed?" + urllib.parse.urlencode(
                 {
                     "url": tweet_url,
                     "lang": "ja",
@@ -207,7 +207,7 @@ def define_env(env):
 
         # script タグを除去（widgets.js は別途1回だけ読み込む）
         html = re.sub(
-            r"<script[^>]*twitter\.com/widgets\.js[^>]*></script>",
+            r"<script[^>]*(?:twitter|x)\.com/widgets\.js[^>]*></script>",
             "",
             html,
             flags=re.IGNORECASE,

--- a/scripts/check_links.py
+++ b/scripts/check_links.py
@@ -295,7 +295,7 @@ async def check_quoted_tweet(client: httpx.AsyncClient, html: str) -> str | None
             continue
 
         # 引用ツイートをoEmbedでチェック
-        oembed_url = "https://publish.twitter.com/oembed?" + urllib.parse.urlencode(
+        oembed_url = "https://publish.x.com/oembed?" + urllib.parse.urlencode(
             {"url": resolved_url}
         )
         try:
@@ -310,7 +310,7 @@ async def check_quoted_tweet(client: httpx.AsyncClient, html: str) -> str | None
 
 async def check_twitter_link(client: httpx.AsyncClient, link: LinkInfo) -> None:
     """Twitter/X リンクをoEmbed APIでチェック"""
-    oembed_url = "https://publish.twitter.com/oembed?" + urllib.parse.urlencode(
+    oembed_url = "https://publish.x.com/oembed?" + urllib.parse.urlencode(
         {"url": link.url}
     )
     try:


### PR DESCRIPTION
## 背景

定期実行している Check Links CI が失敗していた（[該当run](https://github.com/ameyamatmk/shiratamamochi-mashiro-unofficial-wiki/actions/runs/26728858553)）。

`publish.twitter.com/oembed` が `publish.x.com/oembed` へ **301リダイレクト**するようになり、リンクチェッカー(`check_links.py`)が httpx でリダイレクトを追わないため、全X投稿を `HTTP 301` の壊れたリンクと誤判定していた。公開サイトのリンク自体は正常で、CIの誤検知のみが問題。

## 変更内容

- **`scripts/check_links.py`**: oEmbed APIのURLを `publish.x.com` に更新（`check_twitter_link` / `check_quoted_tweet` の2箇所）
- **`main.py`**:
  - 埋め込み生成時の oEmbed URL を `publish.x.com` に更新
  - widgets.js 除去の正規表現を `(?:twitter|x)\.com` に拡張。oEmbedが返すscriptが `platform.x.com/widgets.js` に変わっており、旧正規表現では新規取得分のscriptタグを除去できず重複読み込みになる潜在バグを修正（既存キャッシュの `platform.twitter.com` も引き続きマッチ）

## 方針メモ

`follow_redirects=True` での自動追従ではなく、エンドポイントを明示指定する方針。通常時のリダイレクト往復を無くしつつ、将来また移転した際は気づいて追従する意図。

## 確認

- `curl` で `publish.x.com/oembed` が 200 を返すことを確認
- 実レスポンスHTMLで widgets.js 除去が効くことを確認（before: True → after: False）