### PR TITLE
fix: 非公開になったショート動画の記載を削除

### DIFF
--- a/docs/stream/asmr.md
+++ b/docs/stream/asmr.md
@@ -52,4 +52,3 @@
 | サムネイル | 投稿日 | タイトル |
 |:----------:|--------|----------|
 | {{ youtube_thumbnail("3khcBoKiHgo", short=True) }} | 2026/04/07 | 耳を癒すオイルマッサージ🫶 脳がとろける…✨<br><span class="content-sub">元動画: [疲れたお耳に、ゆったり耳かきとマッサージ✨（2026/03/11）](https://www.youtube.com/watch?v=XRZlVMw-4Ow)</span> |
-| {{ youtube_thumbnail("gPyFnDHivF8", short=True) }} | 2026/04/13 | 疲れたあなたへのご褒美🌙 やわらか膝枕耳かきASMR #睡眠 #癒し<br><span class="content-sub">元動画: [【ASMR】 ひざまくら耳かき✨がんばったあなたへのご褒美✨（2026/04/11）](https://www.youtube.com/watch?v=ceX_qM7H2JE)</span> |


### PR DESCRIPTION
## 変更内容

- `docs/stream/asmr.md` から YouTube ショート動画 `gPyFnDHivF8`（2026/04/13「疲れたあなたへのご褒美🌙 やわらか膝枕耳かきASMR」）の行を削除

## 経緯

リンクチェック CI が検知（#36）。YouTube 側で非公開（`playabilityStatus: LOGIN_REQUIRED` / 「これは非公開動画です」）になっていることを確認済み。
サムネイル画像（mqdefault.jpg）も 404 のため、ページ上で画像が壊れた状態だった。

行の主題がこのショート動画そのものなので、行ごと削除した。
（行内で参照していた元動画 `ceX_qM7H2JE` は別途 ASMR アーカイブ表に記載があり、影響なし）

changelog / 最終更新日は更新していない（メンテナンス対応のため）。

Closes #36
